### PR TITLE
Add fs promises to the VS Code fs shims

### DIFF
--- a/extension.mjs
+++ b/extension.mjs
@@ -259,8 +259,10 @@ class FsWrapper {
 		this.lstat = this.stat;
 		this.promises = {};
 		this.promises.access = promisify(this.fwAccess).bind(this);
+		this.promises.readdir = promisify(this.fwReaddir).bind(this);
 		this.promises.readFile = promisify(this.fwReadFile).bind(this);
 		this.promises.stat = promisify(this.fwStat).bind(this);
+		this.promises.lstat = this.promises.stat;
 	}
 }
 
@@ -282,8 +284,10 @@ class FsNull {
 		this.lstat = this.access;
 		this.promises = {};
 		this.promises.access = promisify(FsNull.fnError);
+		this.promises.readdir = this.promises.access;
 		this.promises.readFile = this.promises.access;
 		this.promises.stat = this.promises.access;
+		this.promises.lstat = this.promises.stat;
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose `fs.promises.readdir` on the VS Code file system wrapper used by the extension
- forward `fs.promises.lstat` to the existing stat implementation for both wrapper types to satisfy libraries requiring it

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68d46bad962c832f9661425010d54461